### PR TITLE
feature -new saved groups added to context menu

### DIFF
--- a/saveGroup.js
+++ b/saveGroup.js
@@ -70,6 +70,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     'tabMasterGroupNames': tabGroups,
                     [groupName]: newGroup,
                 }, () => {
+                    const subContextMenuItem = {
+                        "id": groupName,
+                        "parentId": "addTab",
+                        "title": `Add to ${groupName}`,
+                        "contexts": ["page"] 
+                    }
+                    chrome.contextMenus.create(subContextMenuItem);
                     const notifOptions = {
                         type: 'basic',
                         iconUrl: 'icon48.png',


### PR DESCRIPTION
When a new group is created on the save group page, the context menu is updated to added the new tab group