### PR TITLE
feature -confirm group name overwrites

### DIFF
--- a/manage.html
+++ b/manage.html
@@ -6,8 +6,8 @@
     <link rel="stylesheet" href="manage.css" />
   </head>
   <body>
+    <!-- Modal Start -->
     <div id="confirmDeleteModal" class="modal">
-      <!-- Modal Start -->
       <div class="confirmationContainer">
         <p class="modalText">
           Are you sure you want to delete the '<span id="groupName"></span>'

--- a/saveGroup.css
+++ b/saveGroup.css
@@ -2,6 +2,49 @@ body {
     background-color: #f1f1f1;
 }
 
+.modal {
+    position: absolute;
+    display: flex;
+    visibility: hidden;
+    justify-content: center;
+    align-items: center;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    background-color: #00000000;
+    transition: all 0.5s ease-in-out;
+  }
+  
+  .modalText {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: white;
+    text-shadow: 0px 1px 1px black, 0px -1px 1px black, 1px 0px 1px black,
+    -1px 0px 1px black;
+  }
+
+  .showModal {
+    display: flex;
+    visibility: visible;
+    background-color: #0000007d;
+    backdrop-filter: blur(1.5px);
+  }
+
+  .confirmBtnsContainer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  #confirmBtn {
+    margin-right: 15px;
+  }
+  
+  #cancelBtn {
+    margin-left: 15px;
+  }
+
 .contentContainer {
     min-width: 700px;
     width: 75%;

--- a/saveGroup.html
+++ b/saveGroup.html
@@ -6,6 +6,20 @@
         <link rel="stylesheet" href="saveGroup.css">
     </head>
     <body>
+        <!-- Modal Start -->
+    <div id="confirmOverwriteModal" class="modal">
+        <div class="confirmationContainer">
+          <p class="modalText">
+            There is already a group with the name '<span id="groupNameSpan"></span>'
+          </p>
+          <P class="modalText">Do you want to overwrite this group?</P>
+          <div class="confirmBtnsContainer">
+            <button id="confirmBtn">Confirm</button>
+            <button id="cancelBtn">Cancel</button>
+          </div>
+        </div>
+      </div>
+      <!-- Modal End -->
         <div class="contentContainer">
             <a href="manage.html">Manage Groups</a>
             <h2 class="saveGroupHeader">These are the <span id="tabCount"></span> tabs open in this window</h2>


### PR DESCRIPTION
When a user attempts to save a tab group with the name of a tab group that already exists a modal appears that asks for confirmation before overwriting the tab group