### PR TITLE
Add update tab group feature

### DIFF
--- a/manage.js
+++ b/manage.js
@@ -68,6 +68,16 @@ document.addEventListener("DOMContentLoaded", () => {
           const tabGroupWindows = storage.tabGroupWindows || {};
           tabGroupWindows[currentWindow] = groupName;
           chrome.storage.local.set({tabGroupWindows}, () => {
+            chrome.windows.onRemoved.addListener( function clearStorage(closedWindow) {
+              if (closedWindow === currentWindow) {
+                chrome.storage.local.get(['tabGroupWindows'], (storage) => {
+                  const currentTabGroupWindows = storage.tabGroupWindows || {};
+                  delete currentTabGroupWindows[closedWindow];
+                  chrome.windows.onRemoved.removeListener(clearStorage);
+                  chrome.storage.local.set({tabGroupWindows: currentTabGroupWindows});
+                });
+              }
+            });
             chrome.tabs.getCurrent(({id: currentTab}) => {
               chrome.tabs.remove(currentTab);
             });

--- a/manage.js
+++ b/manage.js
@@ -32,7 +32,6 @@ document.addEventListener("DOMContentLoaded", () => {
           clearInterval(styleTimer);
         } else {
           currentTabIndex -= 1;
-          console.log('In style timer ', currentTabIndex);
           groupTabElems[currentTabIndex].classList.remove('hidden');
         }
     }, 225);
@@ -64,10 +63,15 @@ document.addEventListener("DOMContentLoaded", () => {
   const openTabs = (groupName) => {
     chrome.storage.sync.get(groupName, (storage) => {
       const tabUrls = storage[groupName].map((tab) => tab.url);
-      chrome.windows.create({ url: tabUrls }, (window) => {
-        chrome.tabs.getCurrent(({id: currentTab}) => {
-          console.log(currentTab);
-          chrome.tabs.remove(currentTab);
+      chrome.windows.create({ url: tabUrls }, ({id: currentWindow}) => {
+        chrome.storage.local.get(['tabGroupWindows'], (storage) => {
+          const tabGroupWindows = storage.tabGroupWindows || {};
+          tabGroupWindows[currentWindow] = groupName;
+          chrome.storage.local.set({tabGroupWindows}, () => {
+            chrome.tabs.getCurrent(({id: currentTab}) => {
+              chrome.tabs.remove(currentTab);
+            });
+          });
         });
       });
     });

--- a/popup.css
+++ b/popup.css
@@ -1,13 +1,31 @@
 body {
   margin-bottom: -9px;
-  background-color: coral;
+}
+
+.hidden {
+  display: none;
 }
 
 .popupMenuContainer {
-  width: 200px;
+  min-width: 200px;
   padding: 0px;
   margin: -9px;
   user-select: none;
+}
+
+.popupMenuHeaderContainer {
+  width: 100%;
+}
+
+.popupMenuHeaderText {
+  text-align: center;
+  font-weight: bold;
+  margin: 2px 0px;
+}
+
+.divider {
+  border: .5px solid rgb(202, 194, 194);
+  margin: 0px;
 }
 
 .popupMenuItem {
@@ -21,9 +39,9 @@ body {
 }
 
 .popupMenuText {
-  /* text-align: center; */
   margin: 0px;
   padding: 3px 10px;
+  white-space: nowrap;
 }
 
 .horizontalRule {

--- a/popup.html
+++ b/popup.html
@@ -7,10 +7,17 @@
     </head>
     <body>
         <div class="popupMenuContainer">
+            <div id="popupMenuHeaderContainer" class="popupMenuHeaderContainer hidden">
+                <p class="popupMenuHeaderText">This window is tab group</p>
+                <p class="popupMenuHeaderText">'<span id="popupMenuGroupNameSpan1"></span>'</p>
+                <hr class="divider">
+                <div class="popupMenuItem" id="updateGroupBtn">
+                    <p class="popupMenuText">Update Tabs For Group '<span id="popupMenuGroupNameSpan2"></span>'</p>
+                </div>
+            </div>
             <div class="popupMenuItem" id="createGroupBtn">
                 <p class="popupMenuText">Create New Tab Group</p>
             </div>
-            <!-- <hr class="horizontalRule"> -->
             <div class="popupMenuItem" id="manageGroupsBtn">
                 <p class="popupMenuText">Manage Tab Groups</p>
             </div>

--- a/popup.js
+++ b/popup.js
@@ -1,10 +1,51 @@
 //popup.js is the script that runs in the extension popup html.
 document.addEventListener('DOMContentLoaded', () => {
 
+    (function(){
+        chrome.windows.getCurrent(({id: currentWindow}) => {
+            chrome.storage.local.get(['tabGroupWindows'], (storage) => {
+                const tabGroupWindows = storage.tabGroupWindows || {};
+                if (tabGroupWindows[currentWindow]) {
+                    const groupNameSpan1Elem = document.getElementById('popupMenuGroupNameSpan1');
+                    const groupNameSpan2Elem = document.getElementById('popupMenuGroupNameSpan2');
+                    const menuHeaderContainerElem = document.getElementById('popupMenuHeaderContainer');
+                    groupNameSpan1Elem.innerText = tabGroupWindows[currentWindow];
+                    groupNameSpan2Elem.innerText = tabGroupWindows[currentWindow];
+                    menuHeaderContainerElem.classList.remove('hidden');
+                }
+            });
+        });
+    })();
+
+    const updateTabGroup = () => {
+        chrome.windows.getCurrent(({id: currentWindow}) => {
+            chrome.tabs.query({windowId: currentWindow}, (tabs) => {
+                const tabGroup = [];
+                tabs.forEach(({favIconUrl, title, url}) => tabGroup.push({favIconUrl, title, url}));
+                chrome.storage.local.get(['tabGroupWindows'], (storage) => {
+                    const groupName = storage.tabGroupWindows[currentWindow];
+                    chrome.storage.sync.set({[groupName]: tabGroup}, () => {
+                        const notifOptions = {
+                            type: "basic",
+                            iconUrl: "icon48.png",
+                            title: "Updated!",
+                            message: `Tab group '${groupName}' has been updated.`
+                        }
+                        chrome.notifications.create('updateNotif', notifOptions);
+                        chrome.tabs.getCurrent((tab) => {
+                            chrome.tabs.remove(tab.id);
+                        })
+                    })
+                });
+            });
+        });
+    }
+
     const openTab = (tab) => {
         chrome.tabs.create({url: tab});
     }
     
+    document.getElementById('updateGroupBtn').addEventListener('click', () => updateTabGroup(), false);
     document.getElementById('createGroupBtn').addEventListener('click', () => openTab('saveGroup.html'), false);
     document.getElementById('manageGroupsBtn').addEventListener('click', () => openTab('manage.html'), false);
 

--- a/saveGroup.html
+++ b/saveGroup.html
@@ -27,6 +27,8 @@
                 <h3 class="saveGroupHeader contorlsHeaderText" id="tabsSelectedCount"></h3>
                 <h4 class="saveGroupHeader contorlsInstructionText">Click on tabs to add or remove them from the group. When all of the tabs you want to save in the group are selected enter a name for the group and click the 'Save Group' button or press the 'Enter' key.</h4>
                 <button id="saveGroupBtn">Save Group</button>
+                <!-- Remove after testing -->
+                <!-- <button id="testBtn">Test Remove</button> -->
                 <label for="groupName">Group Name</label>
                 <input id="groupNameInput" type="text" name="groupName" />
             </div>


### PR DESCRIPTION
Tab groups can now be updated from the popup menu. When a tab group is opened the window id  and group name are recorded in local storage as as a key value pair. The popup menu in a tab group window will have the option for the user to 'update' the tab group. Updating the tab group means that all new tabs that were opened in the window will be added to the tab group. All of the existing tabs will also have their urls updated as well.